### PR TITLE
Added dependencies to build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 `git clone https://github.com/sandro-k/MQTTLensChromeApp.git`
 
+`cd MQTTLensChromeApp`
+
 `git submodule init`
+
+`git submodule update`
 
 `npm install`
 
@@ -17,6 +21,16 @@ This will build MQTTlens in to the `build` directory. Navigate to `chrome://exte
 folder as a Chrome App.
 
 To debug MQTTlens installed from the Chrome App Store brows to  [`chrome://inspect/#apps`](chrome://inspect/#apps)
+
+## Other installations needed
+
+You will also need a few other tools installed to properly complete the build:
+
+* Ruby - see https://www.ruby-lang.org/en/
+* NodeJS - see https://nodejs.org/en/
+* bower - `npm install -g bower`
+* sass `gem install sass`
+* Grunt `npm install -g grunt-cli`
 
 ## Live reload 
 


### PR DESCRIPTION
When I first built the code, I didn't do the 'git submodule update' to pull that code in.  So none of those paths were populated, causing the build to fail.  

I also added instructions on some of the other dependencies needed.  